### PR TITLE
Force `overflow: visible` on containers

### DIFF
--- a/src/widget.ts
+++ b/src/widget.ts
@@ -268,7 +268,7 @@ export class AnnotoriusView extends DOMWidgetView {
 
     // Tune notebook elements to display editor properly
     this.displayed.then(() => {
-      this._updateParentOverflowStyle('visible');
+      this._updateParentOverflowStyle('visible !important');
     });
     // Connect Python event
     // FIXME is it a good idea to let user change dynamically the image and/or its size


### PR DESCRIPTION
Some widgets libraries mess up .jupyter-widgets CSS style with `!important` :angry: